### PR TITLE
Mark the start of the Postgresql upgrade

### DIFF
--- a/content/issues/2021-06-04-postgresql-12.md
+++ b/content/issues/2021-06-04-postgresql-12.md
@@ -1,14 +1,11 @@
 ---
 title: PostgreSQL db upgrade
-date: 2021-06-04
-# Before the outage:
-# - set 'date' to date/time when the outage starts
-# - set 'resolved: false'
+date: 2021-06-04 05:00:00
 # After the outage:
-# - set 'resolvedWhen' to date/time when the outage starts
+# - set 'resolvedWhen' to date/time when the outage ended
 # - set 'resolved: true'
-#resolved: false
-resolvedWhen: 2021-06-04
+resolved: false
+resolvedWhen: 2021-06-04 07:00:00
 severity: down
 affected:
   - API
@@ -17,5 +14,4 @@ affected:
 section: issue
 ---
 
-We are about to upgrade our PostgreSQL database from version 10 to version 12.
-If will probably happen around Friday, June 4th.
+Upgrading our PostgreSQL database from version 10 to version 12.


### PR DESCRIPTION
@lbarcziova please merge this before you start the upgrade. After the upgrade is done:
- set `resolvedWhen` to date/time (`date --utc --rfc-3339=seconds`) when the outage ended 
- set `resolved: true`