### PR TITLE
Make creating issues easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.hugo_build.lock
 
 public/
 resources/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+TITLE ?= "Outage"
+FILE_NAME = "$(shell date --iso-8601)-$(shell echo $(TITLE) | tr A-Z a-z | tr ' ' -).md"
+
+help:
+	@echo To create and edit a new issue, run
+	@echo 
+	@echo "    make issue TITLE=\"Something is broken\""
+	@echo
+	@echo and follow the instructions to edit it.
+
+issue:
+	hugo new issues/$(FILE_NAME)
+	$(EDITOR) content/issues/$(FILE_NAME)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ If you forget and realize later, just run:
 
 ## Add new content
 
+### TL;DR
+
+To create and edit a new issue, run `make issue TITLE="Something is broken"`,
+and follow the instructions to edit it.
+
+### In more detail
+
 Create a new file in [content/issues](content/issues) directory.
 The name of the file will be the slug (what shows up in the URL bar).
 

--- a/archetypes/issues.md
+++ b/archetypes/issues.md
@@ -1,0 +1,25 @@
+---
+title: '{{ .File.TranslationBaseName | replaceRE "[0-9]{4}-[0-9]{2}-[0-9]{2}-" "" | replaceRE "-" " " | title }}'
+date: '{{ now.Format "2006-01-02T15:04-07:00" }}'
+affected:
+  - API
+  - Workers
+  - Dashboard
+  - Copr
+  - Testing Farm
+  - Koji
+resolved: false
+resolvedWhen: '{{ now.Format "2006-01-02T15:04-07:00" }}'
+section: issue
+severity: notice | disrupted | down
+---
+
+* TODO Edit the 'title' above.
+* TODO Edit the 'date' above. Set to the future when announcing an upcoming
+  outage, set to the past if the outage has ongoing some time ago.
+* TODO Edit the list of affected components (remove the ones which are not
+  affected)
+* TODO Chose the right 'severity'.
+* TODO Replace these todo-items with a description of the issue.
+* TODO When an issue is resolved, set the time in 'resolvedWhen' and set
+  'resolved' to 'true'.


### PR DESCRIPTION
Don't require issue editors to read through the entire README to create
new issues, but provide a single command way to do it, and use a
template with instructions.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>