### PR TITLE
Fix check-rebase pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
     hooks:
       - id: check-rebase
         args:
-          - git://github.com/packit/status.git
+          - https://github.com/packit/status.git
         stages: [manual, push]

--- a/content/issues/2022-10-13-cluster-upgrade.md
+++ b/content/issues/2022-10-13-cluster-upgrade.md
@@ -6,6 +6,7 @@ resolvedWhen: 2022-10-13T20:37:00+00:00
 section: issue
 severity: notice
 ---
+
 A system upgrade is scheduled to start on Wed Oct 13 19:00 UTC and last approximately 90 minutes.
 
 We do not expect any significant disruption.


### PR DESCRIPTION
[GitHub no longer supports unauthenticated access using the git:// protocol.](https://github.blog/2021-09-01-improving-git-protocol-security-github/)