### PR TITLE
Bump HUGO_VERSION & actions/checkout

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -21,7 +21,7 @@ jobs:
         env:
           CNAME: status.packit.dev
           GITHUB_ACTOR: jpopelka
-          HUGO_VERSION: 0.80.0
+          HUGO_VERSION: 0.98.0
           HUGO_EXTENDED: false
           TARGET_REPO: packit/status-github-pages
           TARGET_BRANCH: main

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It's done automatically with each push to main. We use
 [Hugo Deploy GitHub Pages Action](https://github.com/marketplace/actions/hugo-deploy-github-pages)
 configured in [.github/workflows/deploy-pages.yml](.github/workflows/deploy-pages.yml)
 which pushes the generated content into
-[packit/status.packit.dev-github-pages](https://github.com/packit/status.packit.dev-github-pages)
+[packit/status-github-pages](https://github.com/packit/status-github-pages)
 from where the Github Pages are served.
 The secret used by the action is stored in
 [settings/secrets](https://github.com/packit/status/settings/secrets).

--- a/content/issues/2022-11-28-staging-unstable.md
+++ b/content/issues/2022-11-28-staging-unstable.md
@@ -3,7 +3,7 @@ title: "Staging is unstable"
 date: "2022-11-25T08:35:00+01:00"
 affected:
 resolved: true
-resolvedWhen:  "2022-11-30T14:06:00+01:00"
+resolvedWhen: "2022-11-30T14:06:00+01:00"
 section: issue
 severity: disrupted
 ---


### PR DESCRIPTION
to be in sync with [version in Fedora 37](https://src.fedoraproject.org/rpms/hugo)