### PR TITLE
Workaround for failing deploy-pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
 
       - name: Hugo Deploy GitHub Pages
-        uses: benmatselby/hugo-deploy-gh-pages@master
+        uses: jpopelka/hugo-deploy-gh-pages@safe-directory
         env:
           CNAME: status.packit.dev
           GITHUB_ACTOR: usercont-release-bot


### PR DESCRIPTION
Use forked action with the following commit(s):
https://github.com/jpopelka/hugo-deploy-gh-pages/commits/safe-directory