### PR TITLE
Resolve the Testing Farm on stage

### DIFF
--- a/content/issues/2023-07-24-stage-fw.md
+++ b/content/issues/2023-07-24-stage-fw.md
@@ -1,8 +1,7 @@
 ---
 title: "Staging instance firewall"
 date: "2023-07-24T14:30:00+02:00"
-affected:
-  - Testing Farm
+# affected:
 resolved: false
 # resolvedWhen: "2023-07-19T11:00:00+00:00"
 section: issue
@@ -18,4 +17,5 @@ In case you are using our staging instance and you hit any issues when running `
 
 ## Known Issues
 
-* Testing Farm is currently not available on the staging instance.
+* ~~Testing Farm is currently not available on the staging instance.~~
+  _Edit_: This issue has been fixed as of July 26th 10am.


### PR DESCRIPTION
Testing Farm has been allowed on the firewall, only `propose-downstream` and `pull-from-upstream` may be affected.