### PR TITLE
Workaround for Build and Publish permission issues

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
 
       - name: Hugo Deploy GitHub Pages
-        uses: benmatselby/hugo-deploy-gh-pages@main
+        uses: benmatselby/hugo-deploy-gh-pages@v2.1.1
         env:
           CNAME: status.packit.dev
           GITHUB_ACTOR: usercont-release-bot


### PR DESCRIPTION
Latest changes in this github action (Commits on 3rd of February)
https://github.com/benmatselby/hugo-deploy-gh-pages
make our action fail.
Use an  old version for it.