### PR TITLE
Use hugo-deploy-gh-pages@mainv2.1.0

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
 
       - name: Hugo Deploy GitHub Pages
-        uses: benmatselby/hugo-deploy-gh-pages@v2.1.1
+        uses: benmatselby/hugo-deploy-gh-pages@mainv2.1.0
         env:
           CNAME: status.packit.dev
           GITHUB_ACTOR: usercont-release-bot


### PR DESCRIPTION
Version 2.1.1 includes commits, from February 3rd 2024, that make the action fail.
Use version 2.1.0 instead.