### PR TITLE
Add OpenScanHub to the status page

### DIFF
--- a/archetypes/issues.md
+++ b/archetypes/issues.md
@@ -10,6 +10,8 @@ affected:
   - Koji
   - Bodhi
   - OpenScanHub
+  - Image Builder
+  - Anitya (Release Monitoring)
 resolved: false
 resolvedWhen: "{{ now.Format "2006-01-02T15:04:00-07:00" }}"
 section: issue

--- a/archetypes/issues.md
+++ b/archetypes/issues.md
@@ -9,6 +9,7 @@ affected:
   - Testing Farm
   - Koji
   - Bodhi
+  - OpenScanHub
 resolved: false
 resolvedWhen: "{{ now.Format "2006-01-02T15:04:00-07:00" }}"
 section: issue

--- a/archetypes/issues.md
+++ b/archetypes/issues.md
@@ -5,13 +5,16 @@ affected:
   - API
   - Workers
   - Dashboard
+
   - Copr
   - Testing Farm
+  - Image Builder
+  - OpenScanHub
+
+  - Anitya (Release Monitoring)
   - Koji
   - Bodhi
-  - OpenScanHub
-  - Image Builder
-  - Anitya (Release Monitoring)
+
 resolved: false
 resolvedWhen: "{{ now.Format "2006-01-02T15:04:00-07:00" }}"
 section: issue

--- a/config.yml
+++ b/config.yml
@@ -176,6 +176,9 @@ params:
     - name: Bodhi
       description: bodhi.fedoraproject.org
       category: Others
+    - name: OpenScanHub
+      description: openscanhub.fedoraproject.org
+      category: Others
 
   # What date format to use?
   #

--- a/config.yml
+++ b/config.yml
@@ -177,10 +177,16 @@ params:
     - name: Testing Farm
       description: api.dev.testing-farm.io - If it's down, we can't run tests.
       category: External Upstream Systems
+    - name: Image Builder
+      description: console.redhat.com/insights/image-builder
+      category: External Upstream Systems
     - name: OpenScanHub
       description: openscanhub.fedoraproject.org
       category: External Upstream Systems
 
+    - name: Anitya (Release Monitoring)
+      description: release-monitoring.org
+      category: External Downstream Systems
     - name: Koji
       description: koji.fedoraproject.org
       category: External Downstream Systems

--- a/config.yml
+++ b/config.yml
@@ -144,8 +144,14 @@ params:
   categories:
     - name: Core
       description: Systems we have complete control over
-    - name: Others
-      description: Systems we use, but have no direct control over
+    - name: External Upstream Systems
+      description: >
+        Systems that are utilized mainly on upstream, but we have no direct
+        control over
+    - name: External Downstream Systems
+      description: >
+        Systems that are utilized mainly on downstream, but we have no direct
+        control over
 
   # These are your systems. Change them to
   # change the amount of components.
@@ -164,21 +170,23 @@ params:
     - name: Dashboard
       description: dashboard.packit.dev
       category: Core
+
     - name: Copr
       description: copr.fedorainfracloud.org - If it's down, we can't build your packages.
-      category: Others
+      category: External Upstream Systems
     - name: Testing Farm
       description: api.dev.testing-farm.io - If it's down, we can't run tests.
-      category: Others
-    - name: Koji
-      description: koji.fedoraproject.org
-      category: Others
-    - name: Bodhi
-      description: bodhi.fedoraproject.org
-      category: Others
+      category: External Upstream Systems
     - name: OpenScanHub
       description: openscanhub.fedoraproject.org
-      category: Others
+      category: External Upstream Systems
+
+    - name: Koji
+      description: koji.fedoraproject.org
+      category: External Downstream Systems
+    - name: Bodhi
+      description: bodhi.fedoraproject.org
+      category: External Downstream Systems
 
   # What date format to use?
   #


### PR DESCRIPTION
Fixes packit/packit.dev#970

TODO:
- [x] with regards to the 94811c1, shouldn't we also include Anitya (Release Monitoring) and Image Builder?