### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: true
 
       - name: Hugo Deploy GitHub Pages
-        uses: benmatselby/hugo-deploy-gh-pages@v2.5.0
+        uses: benmatselby/hugo-deploy-gh-pages@c0e2d9ecd5fb30073fa70210a9029e57e733bff0 # v2.5.0
         env:
           CNAME: status.packit.dev
           GITHUB_ACTOR: usercont-release-bot


### PR DESCRIPTION
Pin all actions to specific commit SHAs to prevent supply chain attacks and ensure reproducible builds.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>